### PR TITLE
Added wget in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /opt
 
 RUN apk add --update \
     ca-certificates \
+    wget \
     python \
     python-dev \
     py-pip \


### PR DESCRIPTION
I got the following problem when running the `docker build`

```
Step 15 : RUN wget https://github.com/Yelp/elastalert/archive/master.zip &&     unzip -- *.zip &&     mv -- elast* ${ELASTALERT_HOME} &&     rm -- *.zip
 ---> Running in 1cf70cac2336
Connecting to github.com (192.30.253.112:443)
wget: can't execute 'ssl_helper': No such file or directory
wget: error getting response: Connection reset by peer
```

It's fixed by adding `wget` in `apk add...`
